### PR TITLE
chore: bump whiskers to 2.1.0

### DIFF
--- a/justfile
+++ b/justfile
@@ -7,39 +7,10 @@ output := "themes"
 whiskers_cmd := "whiskers"
 template_path := "mpv.tera"
 
-# Create the output directory
-setup:
-    # Make the theme directories
-    mkdir -p {{output}}/latte
-    mkdir -p {{output}}/frappe
-    mkdir -p {{output}}/macchiato
-    mkdir -p {{output}}/mocha
-
-    # Build the directory structure for one of the themes
-    mkdir -p {{output}}/latte/rosewater/script-opts
-    mkdir -p {{output}}/latte/flamingo/script-opts
-    mkdir -p {{output}}/latte/pink/script-opts
-    mkdir -p {{output}}/latte/mauve/script-opts
-    mkdir -p {{output}}/latte/red/script-opts
-    mkdir -p {{output}}/latte/maroon/script-opts
-    mkdir -p {{output}}/latte/peach/script-opts
-    mkdir -p {{output}}/latte/yellow/script-opts
-    mkdir -p {{output}}/latte/green/script-opts
-    mkdir -p {{output}}/latte/teal/script-opts
-    mkdir -p {{output}}/latte/sky/script-opts
-    mkdir -p {{output}}/latte/sapphire/script-opts
-    mkdir -p {{output}}/latte/blue/script-opts
-    mkdir -p {{output}}/latte/lavender/script-opts
-
-    # Copy the directory structure for the other themes
-    cp -vr {{output}}/latte/* {{output}}/frappe
-    cp -vr {{output}}/latte/* {{output}}/macchiato
-    cp -vr {{output}}/latte/* {{output}}/mocha
-
 # Remove all files in the output directory
 clean:
     rm -rfv {{output}}
 
 # Generate all four flavors
-all: setup
+all:
     {{whiskers_cmd}} {{template_path}}

--- a/mpv.tera
+++ b/mpv.tera
@@ -1,6 +1,6 @@
 ---
 whiskers:
-  version: 2.0.0
+  version: 2.1.0
   matrix:
     - variant: ["mpv", "script-opts/stats"]
     - flavor


### PR DESCRIPTION
[Whiskers v2.1.0](https://github.com/catppuccin/toolbox/releases/tag/whiskers-v2.1.0) automatically creates the parent directories for you, you can verify this PR locally by running `just clean` followed by `just all`.