### PR TITLE
chore: simplify justfiles

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ _default:
   @just --list
 
 clean:
-    rm -rfv themes/
+  rm -rfv themes/
 
 build:
   whiskers mpv.tera

--- a/justfile
+++ b/justfile
@@ -1,18 +1,8 @@
-# Print out all recipes when running `just`
 _default:
-    @just --list
+  @just --list
 
-# Variables
-output := "themes"
-whiskers_cmd := "whiskers"
-template_path := "mpv.tera"
+build:
+  whiskers mpv.tera
 
-# Remove all files in the output directory
-clean:
-    just uosc/clean
-    rm -rfv {{output}}
-
-# Generate all four flavors
-all:
-    just uosc/all
-    {{whiskers_cmd}} {{template_path}}
+all: build
+  just uosc/build

--- a/justfile
+++ b/justfile
@@ -1,6 +1,9 @@
 _default:
   @just --list
 
+clean:
+    rm -rfv themes/
+
 build:
   whiskers mpv.tera
 

--- a/uosc/justfile
+++ b/uosc/justfile
@@ -1,16 +1,5 @@
-# Print out all recipes when running `just`
 _default:
-    @just --list
+  @just --list
 
-# Variables
-output := "themes"
-whiskers_cmd := "whiskers"
-template_path := "uosc.tera"
-
-# Remove all files in the output directory
-clean:
-    rm -rfv {{output}}
-
-# Generate all four flavors
-all:
-    {{whiskers_cmd}} {{template_path}}
+build:
+  whiskers uosc.tera

--- a/uosc/justfile
+++ b/uosc/justfile
@@ -2,7 +2,7 @@ _default:
   @just --list
 
 clean:
-    rm -rfv themes/
+  rm -rfv themes/
 
 build:
   whiskers uosc.tera

--- a/uosc/justfile
+++ b/uosc/justfile
@@ -1,5 +1,8 @@
 _default:
   @just --list
 
+clean:
+    rm -rfv themes/
+
 build:
   whiskers uosc.tera


### PR DESCRIPTION
Removes unneeded declarations of variables, renames `all` to `build` (`all` is a vestige from when Whiskers lacked matrix features). Also, possibly controversially, I removed the `clean` command - sorta makes sense but as Whiskers overwrites files in place, creates the output directory, and it means you have the output directory hardcoded in two places I think it isn't worth it.