### PR TITLE
fix(uosc): remove quotation marks and semicolon

### DIFF
--- a/uosc/themes/frappe/blue/script-opts/uosc.conf
+++ b/uosc/themes/frappe/blue/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=8caaee,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284";
+color=foreground=8caaee,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284

--- a/uosc/themes/frappe/flamingo/script-opts/uosc.conf
+++ b/uosc/themes/frappe/flamingo/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=eebebe,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284";
+color=foreground=eebebe,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284

--- a/uosc/themes/frappe/green/script-opts/uosc.conf
+++ b/uosc/themes/frappe/green/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=a6d189,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284";
+color=foreground=a6d189,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284

--- a/uosc/themes/frappe/lavender/script-opts/uosc.conf
+++ b/uosc/themes/frappe/lavender/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=babbf1,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284";
+color=foreground=babbf1,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284

--- a/uosc/themes/frappe/maroon/script-opts/uosc.conf
+++ b/uosc/themes/frappe/maroon/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=ea999c,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284";
+color=foreground=ea999c,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284

--- a/uosc/themes/frappe/mauve/script-opts/uosc.conf
+++ b/uosc/themes/frappe/mauve/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=ca9ee6,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284";
+color=foreground=ca9ee6,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284

--- a/uosc/themes/frappe/peach/script-opts/uosc.conf
+++ b/uosc/themes/frappe/peach/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=ef9f76,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284";
+color=foreground=ef9f76,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284

--- a/uosc/themes/frappe/pink/script-opts/uosc.conf
+++ b/uosc/themes/frappe/pink/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=f4b8e4,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284";
+color=foreground=f4b8e4,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284

--- a/uosc/themes/frappe/red/script-opts/uosc.conf
+++ b/uosc/themes/frappe/red/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=e78284,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284";
+color=foreground=e78284,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284

--- a/uosc/themes/frappe/rosewater/script-opts/uosc.conf
+++ b/uosc/themes/frappe/rosewater/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=f2d5cf,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284";
+color=foreground=f2d5cf,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284

--- a/uosc/themes/frappe/sapphire/script-opts/uosc.conf
+++ b/uosc/themes/frappe/sapphire/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=85c1dc,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284";
+color=foreground=85c1dc,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284

--- a/uosc/themes/frappe/sky/script-opts/uosc.conf
+++ b/uosc/themes/frappe/sky/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=99d1db,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284";
+color=foreground=99d1db,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284

--- a/uosc/themes/frappe/teal/script-opts/uosc.conf
+++ b/uosc/themes/frappe/teal/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=81c8be,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284";
+color=foreground=81c8be,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284

--- a/uosc/themes/frappe/yellow/script-opts/uosc.conf
+++ b/uosc/themes/frappe/yellow/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=e5c890,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284";
+color=foreground=e5c890,foreground_text=414559,background=303446,background_text=c6d0f5,curtain=292c3c,success=a6d189,error=e78284

--- a/uosc/themes/latte/blue/script-opts/uosc.conf
+++ b/uosc/themes/latte/blue/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=1e66f5,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39";
+color=foreground=1e66f5,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39

--- a/uosc/themes/latte/flamingo/script-opts/uosc.conf
+++ b/uosc/themes/latte/flamingo/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=dd7878,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39";
+color=foreground=dd7878,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39

--- a/uosc/themes/latte/green/script-opts/uosc.conf
+++ b/uosc/themes/latte/green/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=40a02b,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39";
+color=foreground=40a02b,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39

--- a/uosc/themes/latte/lavender/script-opts/uosc.conf
+++ b/uosc/themes/latte/lavender/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=7287fd,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39";
+color=foreground=7287fd,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39

--- a/uosc/themes/latte/maroon/script-opts/uosc.conf
+++ b/uosc/themes/latte/maroon/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=e64553,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39";
+color=foreground=e64553,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39

--- a/uosc/themes/latte/mauve/script-opts/uosc.conf
+++ b/uosc/themes/latte/mauve/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=8839ef,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39";
+color=foreground=8839ef,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39

--- a/uosc/themes/latte/peach/script-opts/uosc.conf
+++ b/uosc/themes/latte/peach/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=fe640b,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39";
+color=foreground=fe640b,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39

--- a/uosc/themes/latte/pink/script-opts/uosc.conf
+++ b/uosc/themes/latte/pink/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=ea76cb,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39";
+color=foreground=ea76cb,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39

--- a/uosc/themes/latte/red/script-opts/uosc.conf
+++ b/uosc/themes/latte/red/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=d20f39,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39";
+color=foreground=d20f39,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39

--- a/uosc/themes/latte/rosewater/script-opts/uosc.conf
+++ b/uosc/themes/latte/rosewater/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=dc8a78,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39";
+color=foreground=dc8a78,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39

--- a/uosc/themes/latte/sapphire/script-opts/uosc.conf
+++ b/uosc/themes/latte/sapphire/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=209fb5,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39";
+color=foreground=209fb5,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39

--- a/uosc/themes/latte/sky/script-opts/uosc.conf
+++ b/uosc/themes/latte/sky/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=04a5e5,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39";
+color=foreground=04a5e5,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39

--- a/uosc/themes/latte/teal/script-opts/uosc.conf
+++ b/uosc/themes/latte/teal/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=179299,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39";
+color=foreground=179299,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39

--- a/uosc/themes/latte/yellow/script-opts/uosc.conf
+++ b/uosc/themes/latte/yellow/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=df8e1d,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39";
+color=foreground=df8e1d,foreground_text=ccd0da,background=eff1f5,background_text=4c4f69,curtain=e6e9ef,success=40a02b,error=d20f39

--- a/uosc/themes/macchiato/blue/script-opts/uosc.conf
+++ b/uosc/themes/macchiato/blue/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=8aadf4,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796";
+color=foreground=8aadf4,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796

--- a/uosc/themes/macchiato/flamingo/script-opts/uosc.conf
+++ b/uosc/themes/macchiato/flamingo/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=f0c6c6,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796";
+color=foreground=f0c6c6,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796

--- a/uosc/themes/macchiato/green/script-opts/uosc.conf
+++ b/uosc/themes/macchiato/green/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=a6da95,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796";
+color=foreground=a6da95,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796

--- a/uosc/themes/macchiato/lavender/script-opts/uosc.conf
+++ b/uosc/themes/macchiato/lavender/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=b7bdf8,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796";
+color=foreground=b7bdf8,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796

--- a/uosc/themes/macchiato/maroon/script-opts/uosc.conf
+++ b/uosc/themes/macchiato/maroon/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=ee99a0,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796";
+color=foreground=ee99a0,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796

--- a/uosc/themes/macchiato/mauve/script-opts/uosc.conf
+++ b/uosc/themes/macchiato/mauve/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=c6a0f6,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796";
+color=foreground=c6a0f6,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796

--- a/uosc/themes/macchiato/peach/script-opts/uosc.conf
+++ b/uosc/themes/macchiato/peach/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=f5a97f,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796";
+color=foreground=f5a97f,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796

--- a/uosc/themes/macchiato/pink/script-opts/uosc.conf
+++ b/uosc/themes/macchiato/pink/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=f5bde6,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796";
+color=foreground=f5bde6,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796

--- a/uosc/themes/macchiato/red/script-opts/uosc.conf
+++ b/uosc/themes/macchiato/red/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=ed8796,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796";
+color=foreground=ed8796,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796

--- a/uosc/themes/macchiato/rosewater/script-opts/uosc.conf
+++ b/uosc/themes/macchiato/rosewater/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=f4dbd6,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796";
+color=foreground=f4dbd6,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796

--- a/uosc/themes/macchiato/sapphire/script-opts/uosc.conf
+++ b/uosc/themes/macchiato/sapphire/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=7dc4e4,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796";
+color=foreground=7dc4e4,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796

--- a/uosc/themes/macchiato/sky/script-opts/uosc.conf
+++ b/uosc/themes/macchiato/sky/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=91d7e3,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796";
+color=foreground=91d7e3,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796

--- a/uosc/themes/macchiato/teal/script-opts/uosc.conf
+++ b/uosc/themes/macchiato/teal/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=8bd5ca,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796";
+color=foreground=8bd5ca,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796

--- a/uosc/themes/macchiato/yellow/script-opts/uosc.conf
+++ b/uosc/themes/macchiato/yellow/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=eed49f,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796";
+color=foreground=eed49f,foreground_text=363a4f,background=24273a,background_text=cad3f5,curtain=1e2030,success=a6da95,error=ed8796

--- a/uosc/themes/mocha/blue/script-opts/uosc.conf
+++ b/uosc/themes/mocha/blue/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=89b4fa,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8";
+color=foreground=89b4fa,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8

--- a/uosc/themes/mocha/flamingo/script-opts/uosc.conf
+++ b/uosc/themes/mocha/flamingo/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=f2cdcd,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8";
+color=foreground=f2cdcd,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8

--- a/uosc/themes/mocha/green/script-opts/uosc.conf
+++ b/uosc/themes/mocha/green/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=a6e3a1,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8";
+color=foreground=a6e3a1,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8

--- a/uosc/themes/mocha/lavender/script-opts/uosc.conf
+++ b/uosc/themes/mocha/lavender/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=b4befe,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8";
+color=foreground=b4befe,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8

--- a/uosc/themes/mocha/maroon/script-opts/uosc.conf
+++ b/uosc/themes/mocha/maroon/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=eba0ac,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8";
+color=foreground=eba0ac,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8

--- a/uosc/themes/mocha/mauve/script-opts/uosc.conf
+++ b/uosc/themes/mocha/mauve/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=cba6f7,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8";
+color=foreground=cba6f7,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8

--- a/uosc/themes/mocha/peach/script-opts/uosc.conf
+++ b/uosc/themes/mocha/peach/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=fab387,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8";
+color=foreground=fab387,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8

--- a/uosc/themes/mocha/pink/script-opts/uosc.conf
+++ b/uosc/themes/mocha/pink/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=f5c2e7,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8";
+color=foreground=f5c2e7,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8

--- a/uosc/themes/mocha/red/script-opts/uosc.conf
+++ b/uosc/themes/mocha/red/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=f38ba8,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8";
+color=foreground=f38ba8,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8

--- a/uosc/themes/mocha/rosewater/script-opts/uosc.conf
+++ b/uosc/themes/mocha/rosewater/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=f5e0dc,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8";
+color=foreground=f5e0dc,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8

--- a/uosc/themes/mocha/sapphire/script-opts/uosc.conf
+++ b/uosc/themes/mocha/sapphire/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=74c7ec,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8";
+color=foreground=74c7ec,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8

--- a/uosc/themes/mocha/sky/script-opts/uosc.conf
+++ b/uosc/themes/mocha/sky/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=89dceb,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8";
+color=foreground=89dceb,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8

--- a/uosc/themes/mocha/teal/script-opts/uosc.conf
+++ b/uosc/themes/mocha/teal/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=94e2d5,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8";
+color=foreground=94e2d5,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8

--- a/uosc/themes/mocha/yellow/script-opts/uosc.conf
+++ b/uosc/themes/mocha/yellow/script-opts/uosc.conf
@@ -1,1 +1,1 @@
-color = "foreground=f9e2af,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8";
+color=foreground=f9e2af,foreground_text=313244,background=1e1e2e,background_text=cdd6f4,curtain=181825,success=a6e3a1,error=f38ba8

--- a/uosc/uosc.tera
+++ b/uosc/uosc.tera
@@ -7,4 +7,4 @@ whiskers:
   filename: "themes/{{flavor.identifier}}/{{accent}}/script-opts/uosc.conf"
 ---
 {%- set palette = flavor.colors -%}
-color = "foreground={{ palette[accent].hex }},foreground_text={{ palette.surface0.hex }},background={{ palette.base.hex }},background_text={{ palette.text.hex }},curtain={{ palette.mantle.hex }},success={{ palette.green.hex }},error={{ palette.red.hex }}";
+color=foreground={{ palette[accent].hex }},foreground_text={{ palette.surface0.hex }},background={{ palette.base.hex }},background_text={{ palette.text.hex }},curtain={{ palette.mantle.hex }},success={{ palette.green.hex }},error={{ palette.red.hex }}


### PR DESCRIPTION
uosc wasn't recognising the config as it was surrounded by quotation marks and had a semicolon at the end